### PR TITLE
Add spring milestone repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
     jcenter()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases/' }
+    maven { url "https://repo.spring.io/libs-milestone" }
 }
 
 apply from: "https://dl.bintray.com/scalding/generic/waroverlay.gradle"


### PR DESCRIPTION
Gradle build currently relies on `spring-boot-gradle-plugin` milestone 4 which is missing in the current repositories. 
Add the spring libs-milestone repository so build succeeds.